### PR TITLE
Add word wrap feature

### DIFF
--- a/R/ace-editor.R
+++ b/R/ace-editor.R
@@ -17,6 +17,8 @@
 #'   "\code{auto}").
 #' @param fontSize Defines the font size (in px) used in the editor and should 
 #'   be an integer. The default is 12.
+#' @param wordWrap If set to \code{TRUE}, Ace will enable word wrapping.
+#'   Default value is \code{FALSE}.
 #' @import shiny
 #' @examples \dontrun{
 #'  aceEditor("myEditor", "Initial text for editor here", mode="r", 
@@ -26,7 +28,7 @@
 #' @export
 aceEditor <- function(outputId, value, mode, theme, 
                       readOnly=FALSE, height="400px",
-                      fontSize=12){
+                      fontSize=12, wordWrap=FALSE){
   js <- paste("var editor = ace.edit('",outputId,"');",sep="")
   if (!missing(theme)){
     js <- paste(js, "editor.setTheme('ace/theme/",theme,"');",sep="")
@@ -43,6 +45,9 @@ aceEditor <- function(outputId, value, mode, theme,
   if (!is.null(fontSize) && !is.na(as.numeric(fontSize))){
     js <- paste(js, "document.getElementById('",outputId,"').style.fontSize='",
                 as.numeric(fontSize), "px'; ", sep="")
+  }
+  if (wordWrap){
+    js <- paste(js, "editor.getSession().setUseWrapMode(true);", sep="")
   }
   js <- paste(js, "$('#", outputId, "').data('aceEditor',editor);", sep="")
   

--- a/R/update-ace-editor.R
+++ b/R/update-ace-editor.R
@@ -15,6 +15,8 @@
 #'   If \code{FALSE} (the default), it will enable editing.
 #' @param fontSize If set, will update the font size (in px) used in the editor.
 #'   Should be an integer.
+#' @param wordWrap If set to \code{TRUE}, Ace will enable word wrapping.
+#'   Default value is \code{FALSE}.
 #' @examples \dontrun{
 #'  shinyServer(function(input, output, session) {
 #'    observe({
@@ -26,7 +28,7 @@
 #' @author Jeff Allen \email{jeff@@trestletech.com}
 #' @export
 updateAceEditor <- function(session, editorId, value, theme, readOnly, mode,
-                            fontSize){
+                            fontSize, wordWrap){
   if (missing(session) || missing(editorId)){
     stop("Must provide both a session and an editorId to update Ace.")
   }
@@ -47,6 +49,9 @@ updateAceEditor <- function(session, editorId, value, theme, readOnly, mode,
   }
   if (!missing(fontSize)){
     theList["fontSize"] <- fontSize
+  }
+  if (!missing(wordWrap)){
+    theList["wordWrap"] <- wordWrap
   }
   
   session$sendCustomMessage("shinyAce", theList)


### PR DESCRIPTION
Hi Jeff:

I'm using shinyAce for a project of mine and word wrapping would really be useful. I don't know a lick of javascript, but I was able to hack this together based on your existing code and the [ace how-to guide](http://ace.c9.io/#nav=howto). It seems to work well on my Mac. 

Please note that I haven't updated any documentation, since I'm running roxygen2 v4.0.0 and I can't seem to prevent it from rewriting all of your docs.

Comments/criticism welcome.

Cheers,
Nick
