### PR TITLE
update installation syntax

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,7 +31,7 @@ You can install the latest development version of the code using the `devtools` 
 install.packages("devtools")
 
 library(devtools)
-install_github("shinyAce", "trestletech")
+install_github("trestletech/shinyAce")
 ```
 
 ## Getting Started


### PR DESCRIPTION
Changing this as install_github("shinyAce", "trestletech") usage is now deprecated.
Install message gave:
"Warning message:
Username parameter is deprecated. Please use trestletech/shinyAce"
