### PR TITLE
[Completion] Fix AutoCompleteList in Constructor

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -15,7 +15,8 @@ License: MIT + file LICENSE
 Depends:
     R (>= 3.4.0)
 Imports:
-    shiny (>= 1.0.5)
+    shiny (>= 1.0.5),
+    jsonlite
 Suggests:
     testthat (>= 2.0.0),
     dplyr (>= 0.7.4)

--- a/R/ace-editor.R
+++ b/R/ace-editor.R
@@ -282,7 +282,7 @@ aceEditor <- function(
       id = outputId, 
       class = "shiny-ace", 
       style = paste("height:", validateCssUnit(height)),
-      `data-autoCompleteList` = autoCompleteList
+      `data-auto-complete-list` = jsonlite::toJSON(autoCompleteList)
     ),
     tags$script(type = "text/javascript", HTML(js))
   )

--- a/inst/examples/06-autocomplete/server.R
+++ b/inst/examples/06-autocomplete/server.R
@@ -15,8 +15,8 @@ shinyServer(function(input, output, session) {
   
   ### Auto Compeltion ####
   observe({
-    autoComplete <- if(input$enableAutocomplete) {
-      if(input$enableLiveCompletion) "live" else "enabled"
+    autoComplete <- if (input$enableAutocomplete) {
+      if (input$enableLiveCompletion) "live" else "enabled"
     } else {
       "disabled"
     }
@@ -27,7 +27,7 @@ shinyServer(function(input, output, session) {
   
   #Update static autocomplete list according to dataset
   observe({
-    comps <- if(input$enableNameCompletion) structure(list(colnames(dataset())), names = input$dataset)
+    comps <- if (input$enableNameCompletion) structure(list(colnames(dataset())), names = input$dataset)
     updateAceEditor(session, "mutate", autoCompleteList = comps)
   })
   
@@ -35,7 +35,7 @@ shinyServer(function(input, output, session) {
   mutateOb <- aceAutocomplete("mutate")
   plotOb <- aceAutocomplete("plot")
   observe({
-    if(input$enableRCompletion) {
+    if (input$enableRCompletion) {
       mutateOb$resume()
       plotOb$resume()
     } else {
@@ -54,7 +54,7 @@ shinyServer(function(input, output, session) {
       code1 <- gsub("\\s+$", "", isolate(input$mutate))
       code2 <- gsub("\\s+$", "", isolate(input$plot))
       
-      eval(parse(text = isolate(paste(input$dataset, "%>%", code1, "%>% function(data) {", code2, "}"))))
+      eval(parse(text = isolate(paste(input$dataset, "%>%", code1, "%>% {", code2, "}"))))
     }, error = function(ex) {
       output$error <- renderPrint(ex)
       

--- a/inst/examples/06-autocomplete/ui.R
+++ b/inst/examples/06-autocomplete/ui.R
@@ -12,9 +12,9 @@ shinyUI(fluidPage(
                Use Ctrl+Space for code completion when enabled."),
       radioButtons("dataset", "Dataset: ", c("mtcars", "airquality"), inline = TRUE),
       tags$pre("  %>%"),
-      aceEditor("mutate", mode="r", value="select(wt, mpg) \n", height = "50px"),
-      tags$pre("  %>% function(data) {"),
-      aceEditor("plot", mode="r", value="plot(data) \n", height = "50px"),
+      aceEditor("mutate", mode = "r", value = "select(wt, mpg) \n", height = "50px"),
+      tags$pre("  %>% {"),
+      aceEditor("plot", mode = "r", value = "plot(.) \n", height = "50px"),
       tags$pre("  }"),
       div(actionButton("eval", "Eval"), class = "pull-right"),
       br(), #pad the above pull-right

--- a/inst/www/shinyAce.js
+++ b/inst/www/shinyAce.js
@@ -39,7 +39,7 @@ var langTools = ace.require("ace/ext/language_tools");
 var staticCompleter = {
   getCompletions: function(editor, session, pos, prefix, callback) {
         //if (prefix.length === 0) { callback(null, []); return }
-        var comps = $('#' + editor.container.id).data('autoCompleteList');
+        var comps = $('#' + editor.container.id).data('auto-complete-list');
         if(comps){
           var words = [];
           
@@ -134,7 +134,7 @@ Shiny.addCustomMessageHandler('shinyAce', function(data) {
   }
   
   if (data.hasOwnProperty('autoCompleteList')) {
-    $el.data('autoCompleteList', data.autoCompleteList);
+    $el.data('auto-complete-list', data.autoCompleteList);
   }
   
   if (data.codeCompletions) {


### PR DESCRIPTION
HTML data-* attributes in htmltools no longer automatically converts to JSON from list and attribute key is converted to lower cases. This commit changes the attribute name to lower case and perform explicit JSON conversion. The example has also been fixed for the error that anonymous function needs wrapping braces.

Fixes #48