### PR TITLE
Added showPrintMargin to aceEditor and updateAceEditor

### DIFF
--- a/R/ace-editor.R
+++ b/R/ace-editor.R
@@ -121,6 +121,7 @@ aceEditor <- function(
   autoCompleteList = NULL,
   tabSize = 4, useSoftTabs = TRUE,
   showInvisibles = FALSE, setBehavioursEnabled = TRUE,
+  showPrintMargin = TRUE,
   autoScrollEditorIntoView = FALSE, 
   maxLines = NULL, minLines = NULL,
   placeholder = NULL
@@ -145,6 +146,7 @@ aceEditor <- function(
       tabSize = tabSize,
       useSoftTabs = useSoftTabs,
       showInvisibles = showInvisibles,
+      showPrintMargin = showPrintMargin,
       setBehavioursEnabled = setBehavioursEnabled,
       autoScrollEditorIntoView = autoScrollEditorIntoView,
       maxLines = maxLines,

--- a/R/update-ace-editor.R
+++ b/R/update-ace-editor.R
@@ -44,7 +44,7 @@
 #' @export
 updateAceEditor <- function(
   session, editorId, value, theme, readOnly, mode,
-  fontSize, showLineNumbers, wordWrap, useSoftTabs, tabSize, showInvisibles,
+  fontSize, showLineNumbers, wordWrap, useSoftTabs, tabSize, showInvisibles, showPrintMargin,
   border = c("normal", "alert", "flash"),
   autoComplete = c("disabled", "enabled", "live"),
   autoCompleters = c("snippet", "text", "keyword", "static", "rlang"),
@@ -76,6 +76,7 @@ updateAceEditor <- function(
   if (!missing(tabSize)) theList["tabSize"] <- tabSize
   if (!missing(useSoftTabs)) theList["useSoftTabs"] <- useSoftTabs
   if (!missing(showInvisibles)) theList["showInvisibles"] <- showInvisibles
+  if (!missing(showPrintMargin)) theList["showPrintMargin"] <- showPrintMargin
 
   if (!missing(border)) {
     border <- match.arg(border)

--- a/inst/www/shinyAce.js
+++ b/inst/www/shinyAce.js
@@ -220,6 +220,10 @@
       editor.setOption("showInvisibles", data.showInvisibles);
     }
 
+    if (data.hasOwnProperty("showPrintMargin")) {
+      editor.setOption("showPrintMargin", data.showPrintMargin);
+    }
+
     if (data.hasOwnProperty('border')) {
       var classes = ['acenormal', 'aceflash', 'acealert'];
       $(el).removeClass(classes.join(' '));


### PR DESCRIPTION
[#74](https://github.com/trestletech/shinyAce/issues/74)

Hello,

I've added ```showPrintMargin``` to ```aceEditor.R``` and ```updateAceEditor.R``` and made changes to the ```shinyAce.js```.

```showPrintMargin = FALSE``` is the default. ```showPrintMargin = TRUE``` will hide the vertical margin bar.

Thank you for this package.
